### PR TITLE
Fix workflow trigger syntax

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,7 @@ on:
   push:
     branches:
       - main
-  workflow_run:
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Use correct trigger name (`workflow_dispatch` rather than `workflow_run`) for the manual trigger in the CI/CD workflow.