### PR TITLE
Configure Ktlint for code linting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[**/test/**/*Tests.kt]
+# Ktlint default class signature formatting makes Kotest test classes less readable.
+ktlint_standard_class-signature = disabled

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -1,8 +1,11 @@
+import com.diffplug.gradle.spotless.BaseKotlinExtension
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 plugins {
     kotlin("jvm") version "2.0.0"
     application
+
+    alias(libs.plugins.spotless)
 }
 
 kotlin {
@@ -34,5 +37,19 @@ tasks.test {
             TestLogEvent.STANDARD_OUT,
             TestLogEvent.STANDARD_ERROR,
         )
+    }
+}
+
+spotless {
+    val sharedKtlint: BaseKotlinExtension.() -> Unit = {
+        ktlint(libs.versions.ktlint.get())
+            .setEditorConfigPath("$rootDir/.editorconfig")
+    }
+
+    kotlin {
+        sharedKtlint()
+    }
+    kotlinGradle {
+        sharedKtlint()
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,7 @@
 [versions]
 kotest = "5.9.1"
+ktlint = "1.3.0"
+spotless = "6.25.0"
 
 [libraries]
 kotest-assertions-core = { group = "io.kotest", name = "kotest-assertions-core", version.ref = "kotest" }
@@ -12,3 +14,6 @@ unittest = [
     "kotest-property-core",
     "kotest-runner",
 ]
+
+[plugins]
+spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }


### PR DESCRIPTION
Opt to run Ktlint through the Spotless Gradle plugin.  This should streamline adding additional linters in the future.

Lint both standard Kotlin files and the module's own `build.gradle.kts` file.  We could also lint `settings.gradle.kts` here, but that is probably better left for the root module itself, and will be easier later on, after I've extracted all of this build configuration into an external convention plugin.