### PR TITLE
Configure Kover for code coverage

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 
     alias(libs.plugins.spotless)
     alias(libs.plugins.detekt)
+    alias(libs.plugins.kover)
 }
 
 kotlin {
@@ -61,4 +62,19 @@ detekt {
         "src/test/kotlin",
         "build.gradle.kts",
     )
+}
+
+kover {
+    reports {
+        filters.excludes.classes(application.mainClass)
+
+        verify.rule {
+            minBound(80)
+        }
+
+        total {
+            log.onCheck = true
+            html.onCheck = true
+        }
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 detekt = "1.23.6"
 kotest = "5.9.1"
+kover = "0.8.1"
 ktlint = "1.3.0"
 spotless = "6.25.0"
 
@@ -18,4 +19,5 @@ unittest = [
 
 [plugins]
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }


### PR DESCRIPTION
Even though all professional Kotlin projects I've worked on have used Jacoco, opt to use Kover instead because I know from experience that Jacoco has problems measuring coverage of some Kotlin constructs (e.g. inline functions), and as a first-party JetBrains tool Kover should have better results.

Set an 80% coverage threshold, since in my experience that's about the point at which code coverage usually hits diminishing returns.  Exclude the main class from coverage, since that will be our configuration root and wouldn't be considered testable in most applications (though it probably would be in this project, given its lack of problematic external dependencies).