### PR TITLE
Correct extension on Detekt config file

### DIFF
--- a/cli/src/main/kotlin/aph/pew/kotlin/cli/Main.kt
+++ b/cli/src/main/kotlin/aph/pew/kotlin/cli/Main.kt
@@ -1,5 +1,10 @@
 package aph.pew.kotlin.cli
 
+/**
+ * Main entry point for the CLI.
+ *
+ * Contains no meaningful functionality at present.
+ */
 fun main() {
     hello("World")
 }

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -623,6 +623,7 @@ style:
     active: true
     excludes:
       - '**/test/**'
+      - '**/*.gradle.kts'
     ignoreNumbers:
       - '-1'
       - '0'


### PR DESCRIPTION
When generating the Detekt config file, I tried changing its name from `detekt.yml` to `detekt.yaml` in an attempt to standardize.  I thought I had tested adequately to ensure that the config file was being recognized under that name, but I seem to have been mistaken; I think I must have been testing against a rule that is present in Detekt's default ruleset, which Detekt will use when it can't find an actual configuration file.

Rather than attempting to change the configuration to look for `detekt.yaml`, simply revert the name change; this isn't worth a lot of effort.  Also correct or carve out exclusions for the couple of rules that are flagged now that we're using the correct, stricter configuration.