### PR TITLE
Change package name

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,8 @@
+[*.kt]
+# My GitHub name includes a hyphen, so if I want to use an io.github package name, convention says to use underscore,
+# which this rule forbids.  Disable it in favor of Detekt, which provides a more-flexible version of the same rule.
+ktlint_standard_package-name = disabled
+
 [**/test/**/*Tests.kt]
 # Ktlint default class signature formatting makes Kotest test classes less readable.
 ktlint_standard_class-signature = disabled

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -17,7 +17,7 @@ kotlin {
 }
 
 application {
-    mainClass = "aph.pew.kotlin.cli.MainKt"
+    mainClass = "io.github.aaron_harris.pew.kotlin.cli.MainKt"
 }
 
 repositories {

--- a/cli/src/main/kotlin/io/github/aaron_harris/pew/kotlin/cli/Hello.kt
+++ b/cli/src/main/kotlin/io/github/aaron_harris/pew/kotlin/cli/Hello.kt
@@ -1,3 +1,3 @@
-package aph.pew.kotlin.cli
+package io.github.aaron_harris.pew.kotlin.cli
 
 internal fun hello(name: String): String = "Hello, $name!"

--- a/cli/src/main/kotlin/io/github/aaron_harris/pew/kotlin/cli/Main.kt
+++ b/cli/src/main/kotlin/io/github/aaron_harris/pew/kotlin/cli/Main.kt
@@ -1,4 +1,4 @@
-package aph.pew.kotlin.cli
+package io.github.aaron_harris.pew.kotlin.cli
 
 /**
  * Main entry point for the CLI.

--- a/cli/src/test/kotlin/io/github/aaron_harris/pew/kotlin/cli/HelloTests.kt
+++ b/cli/src/test/kotlin/io/github/aaron_harris/pew/kotlin/cli/HelloTests.kt
@@ -1,4 +1,4 @@
-package aph.pew.kotlin.cli
+package io.github.aaron_harris.pew.kotlin.cli
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -372,7 +372,7 @@ naming:
     privatePropertyPattern: '(_)?[A-Za-z][_A-Za-z0-9]*'
   PackageNaming:
     active: true
-    packagePattern: '[a-z]+(\.[a-z][A-Za-z0-9]*)*'
+    packagePattern: 'io\.github\.aaron_harris(\.[a-z][A-Za-z0-9]*)*'
   TopLevelPropertyNaming:
     active: true
     constantPattern: '[A-Z][_A-Z0-9]*'


### PR DESCRIPTION
While trying to sort out how cross-repository dependencies are going to work (and in particular what a suitable ID would be for the Gradle convention plugins I'm currently developing), I realized that my GitHub account gives me control over the `aaron-harris.github.io` domain, and that it would therefore be natural to use `io.github.aaron_harris` as a JVM root package (following the Java conventions
[here](https://docs.oracle.com/javase/tutorial/java/package/namingpkgs.html) about package names derived from hyphenated domain names).

That doesn't matter much for this project (since it's not a library and shouldn't have external consumers), but I suppose there is a (very small) chance of some other project I eventually create having consumers other than myself, so it would behoove me to go ahead and adopt the forward-proof convention at the outset.

Note that neither Ktlint nor Detekt will accept underscores in package names (and there is another GitHub user with the username `aaronharris`, so simply omitting the underscore would invite collisions).  Disable the Ktlint rule, and configure the Detekt rule so that the one underscore in `aaron_harris` is acceptable, but subpackages still may not contain underscores.