### PR TITLE
Extract build logic to external convention plugin

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,4 +33,11 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
 
       - name: 'Build with Gradle'
-        run: ./gradlew check
+        env:
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          ./gradlew
+          -PgitHubPackagesUsername="$GITHUB_USER"
+          -PgitHubPackagesPassword="$GITHUB_TOKEN"
+          check

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -1,13 +1,6 @@
-import com.diffplug.gradle.spotless.BaseKotlinExtension
-import org.gradle.api.tasks.testing.logging.TestLogEvent
-
 plugins {
-    kotlin("jvm") version "2.0.0"
+    alias(libs.plugins.aph.kotlin)
     application
-
-    alias(libs.plugins.spotless)
-    alias(libs.plugins.detekt)
-    alias(libs.plugins.kover)
 }
 
 kotlin {
@@ -20,61 +13,10 @@ application {
     mainClass = "io.github.aaron_harris.pew.kotlin.cli.MainKt"
 }
 
-repositories {
-    mavenCentral()
+aphKotlin {
+    codeCoverage.excludedClasses.add(application.mainClass)
 }
 
 dependencies {
     testImplementation(libs.bundles.unittest)
-}
-
-tasks.test {
-    useJUnitPlatform()
-
-    testLogging {
-        events(
-            TestLogEvent.PASSED,
-            TestLogEvent.SKIPPED,
-            TestLogEvent.FAILED,
-            TestLogEvent.STANDARD_OUT,
-            TestLogEvent.STANDARD_ERROR,
-        )
-    }
-}
-
-spotless {
-    val sharedKtlint: BaseKotlinExtension.() -> Unit = {
-        ktlint(libs.versions.ktlint.get())
-            .setEditorConfigPath("$rootDir/.editorconfig")
-    }
-
-    kotlin {
-        sharedKtlint()
-    }
-    kotlinGradle {
-        sharedKtlint()
-    }
-}
-
-detekt {
-    source.setFrom(
-        "src/main/kotlin",
-        "src/test/kotlin",
-        "build.gradle.kts",
-    )
-}
-
-kover {
-    reports {
-        filters.excludes.classes(application.mainClass)
-
-        verify.rule {
-            minBound(80)
-        }
-
-        total {
-            log.onCheck = true
-            html.onCheck = true
-        }
-    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,6 @@
 [versions]
-detekt = "1.23.6"
+aph-gradleConventions = "1.0.0"
 kotest = "5.9.1"
-kover = "0.8.1"
-ktlint = "1.3.0"
-spotless = "6.25.0"
 
 [libraries]
 kotest-assertions-core = { group = "io.kotest", name = "kotest-assertions-core", version.ref = "kotest" }
@@ -18,6 +15,4 @@ unittest = [
 ]
 
 [plugins]
-detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
-kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
-spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
+aph-kotlin = { id = "io.github.aaron-harris.gradle-conventions.aph-kotlin", version.ref = "aph-gradleConventions" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,19 @@
 rootProject.name = "pew-kotlin"
 
 include("cli")
+
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal {
+            mavenContent { snapshotsOnly() }
+        }
+        maven {
+            name = "gitHubPackages"
+            url = uri("https://maven.pkg.github.com/aaron-harris/aph-gradle-conventions")
+
+            // GitHub credentials should be set in ~/.gradle/gradle.properties or via CLI
+            credentials(PasswordCredentials::class)
+        }
+    }
+}


### PR DESCRIPTION
Replace as much of the logic in `build.gradle.kts` as possible with the `aph-kotlin` convention plugin just published to GitHub Packages.