### PR TITLE
Set up skeleton of core module

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -18,6 +18,8 @@ aphKotlin {
 }
 
 dependencies {
+    implementation(project(":core"))
+
     testImplementation(libs.bundles.unittest)
 
     implementation(libs.clikt)

--- a/cli/src/main/kotlin/io/github/aaron_harris/pew/kotlin/cli/HelloCommand.kt
+++ b/cli/src/main/kotlin/io/github/aaron_harris/pew/kotlin/cli/HelloCommand.kt
@@ -1,10 +1,11 @@
 package io.github.aaron_harris.pew.kotlin.cli
 
 import com.github.ajalt.clikt.core.CliktCommand
+import io.github.aaron_harris.pew.kotlin.hello
 
 /** A simple Hello World command demonstrating the intended Clikt application structure. */
 class HelloCommand : CliktCommand() {
     override fun run() {
-        echo("Hello, World!")
+        echo(hello("World"))
     }
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+    alias(libs.plugins.aph.kotlin)
+}
+
+kotlin {
+    jvmToolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
+dependencies {
+    testImplementation(libs.bundles.unittest)
+}

--- a/core/src/main/kotlin/io/github/aaron_harris/pew/kotlin/Hello.kt
+++ b/core/src/main/kotlin/io/github/aaron_harris/pew/kotlin/Hello.kt
@@ -1,0 +1,4 @@
+package io.github.aaron_harris.pew.kotlin
+
+/** Temporary Hello World function intended only to demonstrate correct application structure. */
+fun hello(name: String): String = "Hello, $name!"

--- a/core/src/test/kotlin/io/github/aaron_harris/pew/kotlin/HelloTests.kt
+++ b/core/src/test/kotlin/io/github/aaron_harris/pew/kotlin/HelloTests.kt
@@ -1,0 +1,18 @@
+package io.github.aaron_harris.pew.kotlin
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.string
+import io.kotest.property.checkAll
+
+class HelloTests : FunSpec({
+
+    test("Test hello") {
+        checkAll(
+            Arb.string(),
+        ) { name ->
+            hello(name) shouldBe "Hello, $name!"
+        }
+    }
+})

--- a/core/src/test/resources/kotest.properties
+++ b/core/src/test/resources/kotest.properties
@@ -1,0 +1,1 @@
+kotest.framework.classpath.scanning.autoscan.disable=true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,6 @@
 rootProject.name = "pew-kotlin"
 
+include("core")
 include("cli")
 
 pluginManagement {


### PR DESCRIPTION
Add a second module, called `core`.  This is where we will define the central `Exercise` interface that will be shared across all problem families (like Advent of Code or Project Euler) and accessed through the CLI.

At this initial step, we simply create the module itself and delegate to it the Hello World implementation from the CLI.  Which is, of course, a ridiculous level of indirection for the current behavior, but it lets us establish structure before we worry about more meaningful concerns.